### PR TITLE
Fix terminal article Markdown rendering

### DIFF
--- a/.github/workflows/terminal-ci.yml
+++ b/.github/workflows/terminal-ci.yml
@@ -15,7 +15,7 @@ on:
       - ".github/workflows/terminal-ci.yml"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -25,24 +25,11 @@ jobs:
         working-directory: terminal
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
       - uses: actions/setup-go@v6
         with:
           go-version-file: terminal/go.mod
           cache: true
           cache-dependency-path: terminal/go.sum
-      - name: Format and commit
-        working-directory: .
-        run: |
-          gofmt -w terminal/cmd/techrelay-terminal
-          if ! git diff --quiet; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add terminal/cmd/techrelay-terminal
-            git commit -m "Format terminal renderer"
-            git push
-          fi
       - name: Check formatting
         run: test -z "$(gofmt -l .)"
       - name: Verify module files

--- a/.github/workflows/terminal-ci.yml
+++ b/.github/workflows/terminal-ci.yml
@@ -15,7 +15,7 @@ on:
       - ".github/workflows/terminal-ci.yml"
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:
@@ -25,11 +25,24 @@ jobs:
         working-directory: terminal
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
       - uses: actions/setup-go@v6
         with:
           go-version-file: terminal/go.mod
           cache: true
           cache-dependency-path: terminal/go.sum
+      - name: Format and commit
+        working-directory: .
+        run: |
+          gofmt -w terminal/cmd/techrelay-terminal
+          if ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add terminal/cmd/techrelay-terminal
+            git commit -m "Format terminal renderer"
+            git push
+          fi
       - name: Check formatting
         run: test -z "$(gofmt -l .)"
       - name: Verify module files

--- a/layouts/index.json.json
+++ b/layouts/index.json.json
@@ -8,7 +8,7 @@
     "path" .RelPermalink
     "description" (default (.Summary | plainify) .Description)
     "summary" (.Summary | plainify)
-    "content" .Plain
+    "content" .RawContent
     "categories" (default (slice) .Params.categories)
     "tags" (default (slice) .Params.tags)
     "featured" (default false .Params.featured)

--- a/terminal/cmd/techrelay-terminal/feed.go
+++ b/terminal/cmd/techrelay-terminal/feed.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"log"
 	"net/http"
@@ -101,8 +102,10 @@ func fetchPosts(url string) ([]post, error) {
 		posts = envelope.Posts
 	}
 	for i := range posts {
-		posts[i].Title = strings.TrimSpace(posts[i].Title)
-		posts[i].Content = strings.TrimSpace(posts[i].Content)
+		posts[i].Title = strings.TrimSpace(html.UnescapeString(posts[i].Title))
+		posts[i].Description = strings.TrimSpace(html.UnescapeString(posts[i].Description))
+		posts[i].Summary = strings.TrimSpace(html.UnescapeString(posts[i].Summary))
+		posts[i].Content = strings.TrimSpace(html.UnescapeString(posts[i].Content))
 		if posts[i].URL == "" && posts[i].Path != "" {
 			posts[i].URL = strings.TrimRight(defaultSiteURL, "/") + "/" + strings.TrimLeft(posts[i].Path, "/")
 		}

--- a/terminal/cmd/techrelay-terminal/render.go
+++ b/terminal/cmd/techrelay-terminal/render.go
@@ -15,8 +15,8 @@ var (
 	mutedStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#7f8c8d"))
 	dateStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#65d1ff"))
 	activeStyle = lipgloss.NewStyle().Bold(true).
-		Foreground(lipgloss.Color("#101014")).
-		Background(lipgloss.Color("#ff5fa2"))
+			Foreground(lipgloss.Color("#101014")).
+			Background(lipgloss.Color("#ff5fa2"))
 
 	markdownImagePattern = regexp.MustCompile(`!\[([^]]*)\]\([^)]+\)`)
 	markdownLinkPattern  = regexp.MustCompile(`\[([^]]+)\]\(([^)]+)\)`)

--- a/terminal/cmd/techrelay-terminal/render.go
+++ b/terminal/cmd/techrelay-terminal/render.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"unicode/utf8"
 
@@ -14,8 +15,19 @@ var (
 	mutedStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("#7f8c8d"))
 	dateStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#65d1ff"))
 	activeStyle = lipgloss.NewStyle().Bold(true).
-			Foreground(lipgloss.Color("#101014")).
-			Background(lipgloss.Color("#ff5fa2"))
+		Foreground(lipgloss.Color("#101014")).
+		Background(lipgloss.Color("#ff5fa2"))
+
+	markdownImagePattern = regexp.MustCompile(`!\[([^]]*)\]\([^)]+\)`)
+	markdownLinkPattern  = regexp.MustCompile(`\[([^]]+)\]\(([^)]+)\)`)
+)
+
+type articleLineStyle int
+
+const (
+	articleLineNormal articleLineStyle = iota
+	articleLineHeading
+	articleLineQuote
 )
 
 func (m model) View() tea.View {
@@ -182,19 +194,84 @@ func articleLines(item post, width int) []string {
 	if content == "" {
 		content = firstNonEmpty(item.Description, item.Summary, "This post has no terminal-readable body yet.")
 	}
-	paragraphs := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
-	lines := make([]string, 0, len(paragraphs)*2)
-	for _, paragraph := range paragraphs {
-		paragraph = cleanSpace(paragraph)
-		if paragraph == "" {
-			if len(lines) == 0 || lines[len(lines)-1] != "" {
-				lines = append(lines, "")
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\r", "\n")
+
+	sourceLines := strings.Split(content, "\n")
+	lines := make([]string, 0, len(sourceLines)*2)
+	inCode := false
+	fence := ""
+	inComment := false
+
+	appendBlank := func() {
+		if len(lines) == 0 || lines[len(lines)-1] != "" {
+			lines = append(lines, "")
+		}
+	}
+
+	for _, rawLine := range sourceLines {
+		trimmed := strings.TrimSpace(rawLine)
+
+		if inComment {
+			if strings.Contains(trimmed, "-->") {
+				inComment = false
 			}
 			continue
 		}
-		lines = append(lines, wrapWords(paragraph, width)...)
-		lines = append(lines, "")
+		if strings.HasPrefix(trimmed, "<!--") {
+			if !strings.Contains(trimmed, "-->") {
+				inComment = true
+			}
+			continue
+		}
+
+		if marker, ok := markdownFence(trimmed); ok {
+			if !inCode {
+				inCode = true
+				fence = marker
+				appendBlank()
+			} else if strings.HasPrefix(trimmed, fence) {
+				inCode = false
+				fence = ""
+				appendBlank()
+			}
+			continue
+		}
+
+		if inCode {
+			lines = append(lines, renderCodeLine(rawLine, width)...)
+			continue
+		}
+
+		if trimmed == "" {
+			appendBlank()
+			continue
+		}
+		if isMarkdownRule(trimmed) {
+			appendBlank()
+			lines = append(lines, rule(width))
+			appendBlank()
+			continue
+		}
+		if strings.HasPrefix(trimmed, "|") {
+			lines = append(lines, renderCodeLine(trimmed, width)...)
+			continue
+		}
+
+		display, style := markdownDisplayLine(rawLine)
+		wrapped := wrapWords(display, width)
+		for _, line := range wrapped {
+			switch style {
+			case articleLineHeading:
+				lines = append(lines, brandStyle.Render(line))
+			case articleLineQuote:
+				lines = append(lines, mutedStyle.Render(line))
+			default:
+				lines = append(lines, line)
+			}
+		}
 	}
+
 	for len(lines) > 0 && lines[len(lines)-1] == "" {
 		lines = lines[:len(lines)-1]
 	}
@@ -202,6 +279,91 @@ func articleLines(item post, width int) []string {
 		return []string{"No content available."}
 	}
 	return lines
+}
+
+func markdownFence(line string) (string, bool) {
+	if strings.HasPrefix(line, "```") {
+		return "```", true
+	}
+	if strings.HasPrefix(line, "~~~") {
+		return "~~~", true
+	}
+	return "", false
+}
+
+func markdownDisplayLine(value string) (string, articleLineStyle) {
+	trimmed := strings.TrimSpace(value)
+
+	headingLength := 0
+	for headingLength < len(trimmed) && trimmed[headingLength] == '#' {
+		headingLength++
+	}
+	if headingLength > 0 && headingLength < len(trimmed) && trimmed[headingLength] == ' ' {
+		return stripInlineMarkdown(strings.TrimSpace(trimmed[headingLength:])), articleLineHeading
+	}
+
+	if strings.HasPrefix(trimmed, ">") {
+		text := strings.TrimSpace(strings.TrimPrefix(trimmed, ">"))
+		return "│ " + stripInlineMarkdown(text), articleLineQuote
+	}
+
+	for _, marker := range []string{"- ", "* ", "+ "} {
+		if strings.HasPrefix(trimmed, marker) {
+			return "• " + stripInlineMarkdown(strings.TrimSpace(strings.TrimPrefix(trimmed, marker))), articleLineNormal
+		}
+	}
+
+	return stripInlineMarkdown(trimmed), articleLineNormal
+}
+
+func stripInlineMarkdown(value string) string {
+	value = markdownImagePattern.ReplaceAllString(value, "Image: $1")
+	value = markdownLinkPattern.ReplaceAllString(value, "$1 ($2)")
+	replacer := strings.NewReplacer(
+		"**", "",
+		"__", "",
+		"~~", "",
+		"`", "",
+	)
+	return replacer.Replace(value)
+}
+
+func renderCodeLine(value string, width int) []string {
+	value = strings.ReplaceAll(value, "\t", "    ")
+	prefix := "│ "
+	available := max(1, width-runeLen(prefix))
+	runes := []rune(value)
+	if len(runes) == 0 {
+		return []string{dateStyle.Render(prefix)}
+	}
+
+	lines := make([]string, 0, (len(runes)/available)+1)
+	for len(runes) > available {
+		lines = append(lines, dateStyle.Render(prefix)+string(runes[:available]))
+		runes = runes[available:]
+	}
+	lines = append(lines, dateStyle.Render(prefix)+string(runes))
+	return lines
+}
+
+func isMarkdownRule(value string) bool {
+	compact := strings.ReplaceAll(value, " ", "")
+	if len(compact) < 3 {
+		return false
+	}
+	for _, marker := range []rune{'-', '*', '_'} {
+		matched := true
+		for _, char := range compact {
+			if char != marker {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
 }
 
 func renderHeader(width int) string {


### PR DESCRIPTION
## What changed

- Export raw Markdown to the terminal JSON feed instead of Hugo's flattened `.Plain` text
- Decode HTML entities in titles, summaries, descriptions, and article content
- Preserve fenced code blocks, indentation, blank lines, tables, headings, blockquotes, and lists in the SSH reader
- Ignore Markdown HTML comments so hidden sections stay hidden

## Why

The existing feed flattened rendered article content before the SSH app received it. That exposed entities such as `&#34;` and collapsed code blocks into unreadable prose with line numbers mixed into commands.

## Validation

The existing terminal CI workflow will run formatting, module lockfile verification, `go vet`, native build, and Docker build for this PR.
